### PR TITLE
Add `Record#reload` to refresh an instance from persisted data

### DIFF
--- a/spec/reload_spec.cr
+++ b/spec/reload_spec.cr
@@ -1,0 +1,59 @@
+require "./spec_helper"
+require "sqlite3"
+
+module Orma::ReloadSpec
+  class MyRecord < TestRecord
+    id_column id : Int32?
+    column name : String
+    column title : String?
+  end
+
+  describe "MyRecord#reload" do
+    before_each do
+      MyRecord.continuous_migration!
+    end
+
+    after_each do
+      MyRecord.db.close
+    end
+
+    it "refreshes attributes on the same instance" do
+      rec = MyRecord.create(name: "Foo", title: "Old")
+      stale = MyRecord.find(rec.id)
+      fresh = MyRecord.find(rec.id)
+      fresh.update(name: "Bar", title: nil)
+
+      stale.name.should eq("Foo")
+      stale.title.should eq("Old")
+
+      stale.reload
+
+      stale.name.should eq("Bar")
+      stale.title.should be_nil
+      stale.id.should eq(rec.id)
+    end
+
+    it "returns self" do
+      rec = MyRecord.create(name: "Foo")
+
+      rec.reload.should be(rec)
+    end
+
+    it "raises when called without an id" do
+      rec = MyRecord.new(name: "Unsaved")
+
+      expect_raises(Exception, "Cannot reload record without `id`") do
+        rec.reload
+      end
+    end
+
+    it "raises when the row no longer exists" do
+      rec = MyRecord.create(name: "Foo")
+      rec.destroy
+
+      expect_raises(Orma::DBError) do
+        rec.reload
+      end
+    end
+  end
+end

--- a/src/orma/record.cr
+++ b/src/orma/record.cr
@@ -250,8 +250,6 @@ module Orma
       {% end %}
     end
 
-    # This stays inlined because Crystal requires ivars to be initialized directly in `initialize`.
-    # `#reload` uses `load_attributes_from_result_set` below, which mirrors this loading behavior.
     def initialize(db_res : DB::ResultSet)
       {% begin %}
         {% for model_col in @type.instance_vars.select { |var| var.annotation(Column) || var.annotation(IdColumn) } %}
@@ -269,16 +267,12 @@ module Orma
           end
         end
         {% for model_col in @type.instance_vars.select { |var| var.annotation(Column) || var.annotation(IdColumn) } %}
-          if %value{model_col.id}.nil?
-            {% if model_col.type.nilable? %}
-              @{{model_col.name}} = nil
-            {% else %}
-              {% unless model_col.has_default_value? %}
-                raise "nil value encountered for `@{{model_col}}`"
-              {% end %}
-            {% end %}
-          else
+          unless %value{model_col.id}.nil?
             @{{model_col.name}} = ::Orma::Attribute.new(self.class, {{model_col.name.symbolize}}, %value{model_col.id})
+          else
+            {% unless model_col.type.nilable? || model_col.has_default_value? %}
+              raise "nil value encountered for `@{{model_col}}`"
+            {% end %}
           end
         {% end %}
       {% end %}

--- a/src/orma/record.cr
+++ b/src/orma/record.cr
@@ -270,8 +270,12 @@ module Orma
           unless %value{model_col.id}.nil?
             @{{model_col.name}} = ::Orma::Attribute.new(self.class, {{model_col.name.symbolize}}, %value{model_col.id})
           else
-            {% unless model_col.type.nilable? || model_col.has_default_value? %}
-              raise "nil value encountered for `@{{model_col}}`"
+            {% if model_col.type.nilable? %}
+              @{{model_col.name}} = nil
+            {% else %}
+              {% unless model_col.has_default_value? %}
+                raise "nil value encountered for `@{{model_col}}`"
+              {% end %}
             {% end %}
           end
         {% end %}
@@ -367,6 +371,29 @@ module Orma
       where(id: id).first?
     end
 
+    def reload
+      unless _id = id.try(&.value)
+        raise "Cannot reload record without `id`"
+      end
+
+      sql = String.build do |qry|
+        qry << "SELECT * FROM "
+        qry << table_name
+        qry << " WHERE id="
+        qry << _id
+        qry << " LIMIT 1"
+      end
+      begin
+        db.query_one(sql) do |res|
+          load_attributes_from_result_set(res)
+        end
+      rescue err
+        raise DBError.new(err, sql)
+      end
+
+      self
+    end
+
     # :nodoc:
     def self.query_one(sql)
       db.query_one(sql) do |res|
@@ -413,6 +440,38 @@ module Orma
 
     def transaction(&block : -> T) : T forall T
       self.class.transaction(&block)
+    end
+
+    private def load_attributes_from_result_set(db_res : DB::ResultSet)
+      {% begin %}
+        {% for model_col in @type.instance_vars.select { |var| var.annotation(Column) || var.annotation(IdColumn) } %}
+          %value{model_col.id} = nil
+        {% end %}
+
+        db_res.each_column do |column|
+          case column
+            {% for model_col in @type.instance_vars.select { |var| var.annotation(Column) || var.annotation(IdColumn) } %}
+              when {{model_col.name.stringify}}, {{"_" + model_col.name.stringify + "_deprecated"}}
+                {% col_type = model_col.type.union_types.find { |t| t != Nil }.type_vars.first %}
+                {% read_type = model_col.type.nilable? ? "#{col_type}?".id : col_type %}
+                %value{model_col.id} = db_res.read({{read_type}})
+            {% end %}
+          end
+        end
+        {% for model_col in @type.instance_vars.select { |var| var.annotation(Column) || var.annotation(IdColumn) } %}
+          unless %value{model_col.id}.nil?
+            @{{model_col.name}} = ::Orma::Attribute.new(self.class, {{model_col.name.symbolize}}, %value{model_col.id})
+          else
+            {% if model_col.type.nilable? %}
+              @{{model_col.name}} = nil
+            {% else %}
+              {% unless model_col.has_default_value? %}
+                raise "nil value encountered for `@{{model_col}}`"
+              {% end %}
+            {% end %}
+          end
+        {% end %}
+      {% end %}
     end
 
     private def self.transaction_on_connection(connection : DB::Connection, &block : -> T) : T forall T

--- a/src/orma/record.cr
+++ b/src/orma/record.cr
@@ -250,6 +250,8 @@ module Orma
       {% end %}
     end
 
+    # This stays inlined because Crystal requires ivars to be initialized directly in `initialize`.
+    # `#reload` uses `load_attributes_from_result_set` below, which mirrors this loading behavior.
     def initialize(db_res : DB::ResultSet)
       {% begin %}
         {% for model_col in @type.instance_vars.select { |var| var.annotation(Column) || var.annotation(IdColumn) } %}
@@ -267,17 +269,16 @@ module Orma
           end
         end
         {% for model_col in @type.instance_vars.select { |var| var.annotation(Column) || var.annotation(IdColumn) } %}
-          if !%value{model_col.id}.nil?
-            @{{model_col.name}} = ::Orma::Attribute.new(self.class, {{model_col.name.symbolize}}, %value{model_col.id})
-          else
+          if %value{model_col.id}.nil?
             {% if model_col.type.nilable? %}
-              # Keep model state aligned with DB NULL values instead of retaining stale attributes.
               @{{model_col.name}} = nil
             {% else %}
-              {% if !model_col.has_default_value? %}
+              {% unless model_col.has_default_value? %}
                 raise "nil value encountered for `@{{model_col}}`"
               {% end %}
             {% end %}
+          else
+            @{{model_col.name}} = ::Orma::Attribute.new(self.class, {{model_col.name.symbolize}}, %value{model_col.id})
           end
         {% end %}
       {% end %}
@@ -461,17 +462,17 @@ module Orma
           end
         end
         {% for model_col in @type.instance_vars.select { |var| var.annotation(Column) || var.annotation(IdColumn) } %}
-          if !%value{model_col.id}.nil?
-            @{{model_col.name}} = ::Orma::Attribute.new(self.class, {{model_col.name.symbolize}}, %value{model_col.id})
-          else
+          if %value{model_col.id}.nil?
             {% if model_col.type.nilable? %}
               # Keep model state aligned with DB NULL values instead of retaining stale attributes.
               @{{model_col.name}} = nil
             {% else %}
-              {% if !model_col.has_default_value? %}
+              {% unless model_col.has_default_value? %}
                 raise "nil value encountered for `@{{model_col}}`"
               {% end %}
             {% end %}
+          else
+            @{{model_col.name}} = ::Orma::Attribute.new(self.class, {{model_col.name.symbolize}}, %value{model_col.id})
           end
         {% end %}
       {% end %}

--- a/src/orma/record.cr
+++ b/src/orma/record.cr
@@ -267,13 +267,14 @@ module Orma
           end
         end
         {% for model_col in @type.instance_vars.select { |var| var.annotation(Column) || var.annotation(IdColumn) } %}
-          unless %value{model_col.id}.nil?
+          if !%value{model_col.id}.nil?
             @{{model_col.name}} = ::Orma::Attribute.new(self.class, {{model_col.name.symbolize}}, %value{model_col.id})
           else
             {% if model_col.type.nilable? %}
+              # Keep model state aligned with DB NULL values instead of retaining stale attributes.
               @{{model_col.name}} = nil
             {% else %}
-              {% unless model_col.has_default_value? %}
+              {% if !model_col.has_default_value? %}
                 raise "nil value encountered for `@{{model_col}}`"
               {% end %}
             {% end %}
@@ -442,6 +443,7 @@ module Orma
       self.class.transaction(&block)
     end
 
+    # Used by `#reload` to refresh attributes in-place on an existing record instance.
     private def load_attributes_from_result_set(db_res : DB::ResultSet)
       {% begin %}
         {% for model_col in @type.instance_vars.select { |var| var.annotation(Column) || var.annotation(IdColumn) } %}
@@ -459,13 +461,14 @@ module Orma
           end
         end
         {% for model_col in @type.instance_vars.select { |var| var.annotation(Column) || var.annotation(IdColumn) } %}
-          unless %value{model_col.id}.nil?
+          if !%value{model_col.id}.nil?
             @{{model_col.name}} = ::Orma::Attribute.new(self.class, {{model_col.name.symbolize}}, %value{model_col.id})
           else
             {% if model_col.type.nilable? %}
+              # Keep model state aligned with DB NULL values instead of retaining stale attributes.
               @{{model_col.name}} = nil
             {% else %}
-              {% unless model_col.has_default_value? %}
+              {% if !model_col.has_default_value? %}
                 raise "nil value encountered for `@{{model_col}}`"
               {% end %}
             {% end %}


### PR DESCRIPTION
## Summary
- add `Orma::Record#reload` to re-query the current row by `id` and replace attributes on the same instance
- raise `"Cannot reload record without \`id\`"` when reload is called on an unsaved record
- keep DB error wrapping behavior when the underlying row no longer exists
- ensure nilable attributes are set to `nil` when loading `NULL` values from result sets
- add `spec/reload_spec.cr` covering stale-instance refresh, return value, unsaved-record behavior, and missing-row behavior

## Testing
- `CRYSTAL_CACHE_DIR=.crystal-cache crystal spec`