### PR TITLE
Add limit support to record query classes

### DIFF
--- a/spec/limit_spec.cr
+++ b/spec/limit_spec.cr
@@ -1,0 +1,33 @@
+require "./spec_helper"
+
+module Orma::LimitSpec
+  class Model < TestRecord
+    id_column id : Int64
+    column name : String
+  end
+
+  describe "Model.all.limit" do
+    before_each do
+      Model.continuous_migration!
+      Model.create(name: "One")
+      Model.create(name: "Two")
+      Model.create(name: "Three")
+    end
+
+    after_each do
+      Model.db.close
+    end
+
+    it "adds a LIMIT clause to the query" do
+      Model.all.order_by_id!.limit(2).map(&.name.value).should eq(["One", "Two"])
+    end
+
+    it "overwrites the previous limit when called twice" do
+      Model.all.order_by_id!.limit(1).limit(2).map(&.name.value).should eq(["One", "Two"])
+    end
+
+    it "unsets the limit when called with nil" do
+      Model.all.order_by_id!.limit(1).limit(nil).map(&.name.value).should eq(["One", "Two", "Three"])
+    end
+  end
+end

--- a/src/orma/query.cr
+++ b/src/orma/query.cr
@@ -31,6 +31,7 @@ abstract class Orma::Query
   end
 
   getter orderings : Array(Ordering) = [] of Ordering
+  @limit : Int64?
 
   def initialize(**conditions : **K) forall K
     where(**conditions)
@@ -75,7 +76,17 @@ abstract class Orma::Query
     self
   end
 
-  def find_each(*, batch_size = 1000)
+  def limit(limit : Int)
+    @limit = limit.to_i64
+    self
+  end
+
+  def limit(_limit : Nil)
+    @limit = nil
+    self
+  end
+
+  def find_each(*, batch_size = 1000, &)
     if (total_count = count) > batch_size
       ((total_count // batch_size) + 1).times do |i|
         load_batch(i, batch_size).each do |item|
@@ -131,23 +142,32 @@ abstract class Orma::Query
   end
 
   private def count_query
-    build_query("COUNT(*)")
+    build_query("COUNT(*)", include_limit: false)
   end
 
   private def find_all_query
     build_query("*")
   end
 
-  private def build_query(select_clause)
+  private def build_query(select_clause, *, include_limit = true)
     String.build do |str|
       str << "SELECT #{select_clause} FROM #{table_name}"
       str << where_clause
       str << order_clause
+      if include_limit
+        str << limit_clause
+      end
     end
   end
 
+  private def limit_clause
+    return nil unless limit = @limit
+
+    " LIMIT #{limit}"
+  end
+
   private def load_batch(batch_no, batch_size)
-    sql = "#{find_all_query} LIMIT #{batch_size} OFFSET #{batch_no * batch_size}"
+    sql = "#{build_query("*", include_limit: false)} LIMIT #{batch_size} OFFSET #{batch_no * batch_size}"
     begin
       db.query(sql) do |res|
         load_many_from_result(res)


### PR DESCRIPTION
## Summary
This change adds a `#limit` API to record query classes so query result size can be constrained and reset.

## What changed
- Added `Orma::Query#limit(limit : Int)` to set a query limit.
- Added `Orma::Query#limit(nil)` to unset a previously configured limit.
- Added SQL `LIMIT` clause rendering for normal select queries.
- Kept count and batch loading query construction safe by excluding query-level limits from internal count/batch builders.

## Tests
- Added `spec/limit_spec.cr` covering:
 - adding a limit clause behaviorally (`limit(2)`)
 - overriding previous limit (`limit(1).limit(2)`)
 - unsetting limit with `nil` (`limit(1).limit(nil)`)

- Ran full test suite:
 - `CRYSTAL_CACHE_DIR=/tmp/orma-crystal-cache crystal spec`
 - Result: `96 examples, 0 failures, 0 errors, 0 pending`