### PR TITLE
Use bound parameters for runtime SQL execution

### DIFF
--- a/spec/error_spec.cr
+++ b/spec/error_spec.cr
@@ -32,7 +32,7 @@ module Orma::ErrorSpec
           Record.where({"id" => [1_i64, 2_i64]}).to_a
         end
 
-        err.message.should eq("SQLite3::Exception: no such table: orma_error_spec_records\n\nSQL Query: SELECT * FROM orma_error_spec_records WHERE id IN (?, ?)")
+        err.message.should eq("SQLite3::Exception: no such table: orma_error_spec_records\n\nSQL Query: SELECT * FROM orma_error_spec_records WHERE id IN (?,?)")
       end
     end
 

--- a/spec/error_spec.cr
+++ b/spec/error_spec.cr
@@ -14,7 +14,7 @@ module Orma::ErrorSpec
           Record.find(2)
         end
 
-        err.message.should eq("SQLite3::Exception: no such table: orma_error_spec_records\n\nSQL Query: SELECT * FROM orma_error_spec_records WHERE id=2 LIMIT 1")
+        err.message.should eq("SQLite3::Exception: no such table: orma_error_spec_records\n\nSQL Query: SELECT * FROM orma_error_spec_records WHERE id=? LIMIT 1")
       end
     end
 
@@ -24,7 +24,15 @@ module Orma::ErrorSpec
           Record.where({"name" => "test"}).to_a
         end
 
-        err.message.should eq("SQLite3::Exception: no such table: orma_error_spec_records\n\nSQL Query: SELECT * FROM orma_error_spec_records WHERE name='test'")
+        err.message.should eq("SQLite3::Exception: no such table: orma_error_spec_records\n\nSQL Query: SELECT * FROM orma_error_spec_records WHERE name=?")
+      end
+
+      it "uses placeholders for list conditions" do
+        err = expect_raises(Orma::DBError) do
+          Record.where({"id" => [1_i64, 2_i64]}).to_a
+        end
+
+        err.message.should eq("SQLite3::Exception: no such table: orma_error_spec_records\n\nSQL Query: SELECT * FROM orma_error_spec_records WHERE id IN (?, ?)")
       end
     end
 
@@ -34,7 +42,7 @@ module Orma::ErrorSpec
           Record.where({"name" => "test"}).count
         end
 
-        err.message.should eq("SQLite3::Exception: no such table: orma_error_spec_records\n\nSQL Query: SELECT COUNT(*) FROM orma_error_spec_records WHERE name='test'")
+        err.message.should eq("SQLite3::Exception: no such table: orma_error_spec_records\n\nSQL Query: SELECT COUNT(*) FROM orma_error_spec_records WHERE name=?")
       end
     end
 
@@ -44,7 +52,7 @@ module Orma::ErrorSpec
           Record.create(name: "Blah")
         end
 
-        err.message.should eq("SQLite3::Exception: no such table: orma_error_spec_records\n\nSQL Query: INSERT INTO orma_error_spec_records(name) VALUES ('Blah')")
+        err.message.should eq("SQLite3::Exception: no such table: orma_error_spec_records\n\nSQL Query: INSERT INTO orma_error_spec_records(name) VALUES (?)")
       end
     end
 
@@ -57,7 +65,7 @@ module Orma::ErrorSpec
           rec1.save
         end
 
-        err.message.should eq("SQLite3::Exception: no such table: orma_error_spec_records\n\nSQL Query: UPDATE orma_error_spec_records SET name='Bar' WHERE id=1")
+        err.message.should eq("SQLite3::Exception: no such table: orma_error_spec_records\n\nSQL Query: UPDATE orma_error_spec_records SET name=? WHERE id=?")
       end
     end
   end

--- a/spec/where_spec.cr
+++ b/spec/where_spec.cr
@@ -39,5 +39,13 @@ module Orma::WhereSpec
 
       Model.where(name: "One").where(age: 33).where(name: "Two").to_a.should eq([model])
     end
+
+    it "handles SQL-like user input as plain values" do
+      injected = "One' OR 1=1 --"
+      model = Model.create(name: injected, age: 20)
+      Model.create(name: "One", age: 10)
+
+      Model.where(name: injected).to_a.should eq([model])
+    end
   end
 end

--- a/src/ext/array.cr
+++ b/src/ext/array.cr
@@ -4,6 +4,14 @@ require "../orma/to_sql"
 class Array(T)
   include Orma::ToSql
 
+  private struct PreparedParamPlaceholder
+    include Orma::ToSql
+
+    def to_sql_value(io : IO)
+      io << "?"
+    end
+  end
+
   def to_sql_value(io : IO)
     io << "("
     join(io, ",") do |item, io|
@@ -18,12 +26,8 @@ class Array(T)
 
   def to_prepared_where_condition(io : IO, args : Array(DB::Any))
     sql_eq_operator(io)
-    io << "("
-    each_with_index do |item, index|
-      io << ", " if index > 0
-      io << "?"
-      args << item.to_db_param
-    end
-    io << ")"
+
+    Array(PreparedParamPlaceholder).new(size) { PreparedParamPlaceholder.new }.to_sql_value(io)
+    each { |item| args << item.to_db_param }
   end
 end

--- a/src/ext/array.cr
+++ b/src/ext/array.cr
@@ -15,4 +15,15 @@ class Array(T)
   def sql_eq_operator(io)
     io << " IN "
   end
+
+  def to_prepared_where_condition(io : IO, args : Array(DB::Any))
+    sql_eq_operator(io)
+    io << "("
+    each_with_index do |item, index|
+      io << ", " if index > 0
+      io << "?"
+      args << item.to_db_param
+    end
+    io << ")"
+  end
 end

--- a/src/ext/int32.cr
+++ b/src/ext/int32.cr
@@ -8,6 +8,10 @@ struct Int32
     io << self
   end
 
+  def to_db_param : DB::Any
+    to_i64
+  end
+
   def self.from_http_param(str)
     new(str)
   end

--- a/src/ext/int64.cr
+++ b/src/ext/int64.cr
@@ -8,6 +8,10 @@ struct Int64
     io << self
   end
 
+  def to_db_param : DB::Any
+    self
+  end
+
   def self.from_http_param(str)
     new(str)
   end

--- a/src/ext/nil.cr
+++ b/src/ext/nil.cr
@@ -12,7 +12,8 @@ struct Nil
     io << " IS "
   end
 
-  def to_prepared_where_condition(io : IO, args : Array(DB::Any))
-    io << " IS NULL"
+  def to_prepared_where_condition(io : IO, _args : Array(DB::Any))
+    sql_eq_operator(io)
+    to_sql_value(io)
   end
 end

--- a/src/ext/nil.cr
+++ b/src/ext/nil.cr
@@ -11,4 +11,8 @@ struct Nil
   def sql_eq_operator(io : IO)
     io << " IS "
   end
+
+  def to_prepared_where_condition(io : IO, args : Array(DB::Any))
+    io << " IS NULL"
+  end
 end

--- a/src/orma/query.cr
+++ b/src/orma/query.cr
@@ -4,14 +4,11 @@ abstract class Orma::Query
 
   abstract def load_many_from_result(res)
 
+  private record Statement, sql : String, args : Array(DB::Any)
+
   delegate :size, :each, :each_with_index, :map, :first, :first?, :last, :last?, :any?, :empty?, :all?, :none?, :select, :max_by, :min_by, :find, :find!, to: collection
 
-  record Condition(T), name : String, value : T do
-    def to_s(io : IO)
-      io << name
-      value.to_sql_where_condition(io)
-    end
-  end
+  record Condition(T), name : String, value : T
 
   enum Direction
     Asc
@@ -101,11 +98,11 @@ abstract class Orma::Query
   end
 
   def count
-    sql = count_query
+    statement = count_query
     begin
-      db.scalar(sql).as(Int64)
+      db.scalar(statement.sql, args: statement.args).as(Int64)
     rescue err
-      raise DBError.new(err, sql)
+      raise DBError.new(err, statement.sql)
     end
   end
 
@@ -113,7 +110,7 @@ abstract class Orma::Query
     collection.dup.to_a
   end
 
-  private def where_clause
+  private def where_clause(args : Array(DB::Any))
     first = true
 
     String.build do |str|
@@ -126,10 +123,46 @@ abstract class Orma::Query
             str << " AND "
           end
 
-          %value{ivar}.to_s(str)
+          str << %value{ivar}.name
+          append_condition_value(str, args, %value{ivar}.value)
         end
       {% end %}
     end
+  end
+
+  private def append_condition_value(io : IO, args : Array(DB::Any), value : Nil)
+    io << " IS NULL"
+  end
+
+  private def append_condition_value(io : IO, args : Array(DB::Any), value : Array)
+    io << " IN ("
+    value.each_with_index do |item, index|
+      io << ", " if index > 0
+      io << "?"
+      args << to_db_any(item)
+    end
+    io << ")"
+  end
+
+  private def append_condition_value(io : IO, args : Array(DB::Any), value : Orma::Attribute)
+    append_condition_value(io, args, value.value)
+  end
+
+  private def append_condition_value(io : IO, args : Array(DB::Any), value)
+    io << "=?"
+    args << to_db_any(value)
+  end
+
+  private def to_db_any(value : DB::Any) : DB::Any
+    value
+  end
+
+  private def to_db_any(value : Int) : DB::Any
+    value.to_i64
+  end
+
+  private def to_db_any(value) : DB::Any
+    value.as(DB::Any)
   end
 
   private def order_clause
@@ -141,35 +174,42 @@ abstract class Orma::Query
     end
   end
 
-  private def count_query
+  private def count_query : Statement
     build_query("COUNT(*)", include_limit: false)
   end
 
-  private def find_all_query
+  private def find_all_query : Statement
     build_query("*")
   end
 
-  private def build_query(select_clause, *, include_limit = true)
-    String.build do |str|
+  private def build_query(select_clause, *, include_limit = true) : Statement
+    args = [] of DB::Any
+    sql = String.build do |str|
       str << "SELECT #{select_clause} FROM #{table_name}"
-      str << where_clause
+      str << where_clause(args)
       str << order_clause
       if include_limit
-        str << limit_clause
+        str << limit_clause(args)
       end
     end
+    Statement.new(sql, args)
   end
 
-  private def limit_clause
+  private def limit_clause(args : Array(DB::Any))
     return nil unless limit = @limit
 
-    " LIMIT #{limit}"
+    args << limit
+    " LIMIT ?"
   end
 
   private def load_batch(batch_no, batch_size)
-    sql = "#{build_query("*", include_limit: false)} LIMIT #{batch_size} OFFSET #{batch_no * batch_size}"
+    base = build_query("*", include_limit: false)
+    sql = "#{base.sql} LIMIT ? OFFSET ?"
+    args = base.args.dup
+    args << batch_size.to_i64
+    args << (batch_no * batch_size).to_i64
     begin
-      db.query(sql) do |res|
+      db.query(sql, args: args) do |res|
         load_many_from_result(res)
       end
     rescue err
@@ -180,13 +220,13 @@ abstract class Orma::Query
   private def collection
     @collection ||=
       begin
-        sql = find_all_query
+        statement = find_all_query
         begin
-          db.query(sql) do |res|
+          db.query(statement.sql, args: statement.args) do |res|
             load_many_from_result(res)
           end
         rescue err
-          raise DBError.new(err, sql)
+          raise DBError.new(err, statement.sql)
         end
       end
   end

--- a/src/orma/query.cr
+++ b/src/orma/query.cr
@@ -124,45 +124,10 @@ abstract class Orma::Query
           end
 
           str << %value{ivar}.name
-          append_condition_value(str, args, %value{ivar}.value)
+          %value{ivar}.value.to_prepared_where_condition(str, args)
         end
       {% end %}
     end
-  end
-
-  private def append_condition_value(io : IO, args : Array(DB::Any), value : Nil)
-    io << " IS NULL"
-  end
-
-  private def append_condition_value(io : IO, args : Array(DB::Any), value : Array)
-    io << " IN ("
-    value.each_with_index do |item, index|
-      io << ", " if index > 0
-      io << "?"
-      args << to_db_any(item)
-    end
-    io << ")"
-  end
-
-  private def append_condition_value(io : IO, args : Array(DB::Any), value : Orma::Attribute)
-    append_condition_value(io, args, value.value)
-  end
-
-  private def append_condition_value(io : IO, args : Array(DB::Any), value)
-    io << "=?"
-    args << to_db_any(value)
-  end
-
-  private def to_db_any(value : DB::Any) : DB::Any
-    value
-  end
-
-  private def to_db_any(value : Int) : DB::Any
-    value.to_i64
-  end
-
-  private def to_db_any(value) : DB::Any
-    value.as(DB::Any)
   end
 
   private def order_clause

--- a/src/orma/record.cr
+++ b/src/orma/record.cr
@@ -352,15 +352,7 @@ module Orma
     end
 
     def self.find(id : Int8 | Int16 | Int32 | Int64 | Int128 | Orma::Attribute(Int)?)
-      qry = String.build do |str|
-        str << "SELECT * FROM "
-        str << table_name
-        str << " WHERE id"
-        id.to_sql_where_condition(str)
-        str << " LIMIT 1"
-      end
-
-      query_one(qry)
+      query_one("SELECT * FROM #{table_name} WHERE id=? LIMIT 1", to_db_any(id))
     end
 
     def self.find?(id : Int8 | Int16 | Int32 | Int64 | Int128 | Orma::Attribute(Int)?)
@@ -372,15 +364,10 @@ module Orma
         raise "Cannot reload record without `id`"
       end
 
-      sql = String.build do |qry|
-        qry << "SELECT * FROM "
-        qry << table_name
-        qry << " WHERE id="
-        qry << _id
-        qry << " LIMIT 1"
-      end
+      sql = "SELECT * FROM #{table_name} WHERE id=? LIMIT 1"
+      args = [_id] of DB::Any
       begin
-        db.query_one(sql) do |res|
+        db.query_one(sql, args: args) do |res|
           load_attributes_from_result_set(res)
         end
       rescue err
@@ -391,8 +378,8 @@ module Orma
     end
 
     # :nodoc:
-    def self.query_one(sql)
-      db.query_one(sql) do |res|
+    def self.query_one(sql, *args_, args : Enumerable? = nil)
+      db.query_one(sql, *args_, args: args) do |res|
         new(res)
       end
     rescue err
@@ -431,7 +418,12 @@ module Orma
     end
 
     def destroy
-      db.exec("DELETE FROM #{table_name} WHERE id=#{id}")
+      unless _id = id.try(&.value)
+        raise "Cannot destroy record without `id`"
+      end
+
+      sql = "DELETE FROM #{table_name} WHERE id=?"
+      db.exec(sql, _id)
     end
 
     def transaction(&block : -> T) : T forall T
@@ -505,19 +497,21 @@ module Orma
         self.updated_at = Time.utc
       {% end %}
 
+      args = [] of DB::Any
       query = String.build do |qry|
         qry << "UPDATE "
         qry << table_name
         qry << " SET "
         column_values.to_h.join(qry, ", ") do |(k, v), io|
           io << k
-          v.to_sql_update_value(io)
+          io << "=?"
+          args << to_db_any(v)
         end
-        qry << " WHERE id="
-        qry << _id
+        qry << " WHERE id=?"
       end
+      args << _id
       begin
-        db.exec query
+        db.exec(query, args: args)
       rescue err
         raise DBError.new(err, query)
       end
@@ -531,17 +525,21 @@ module Orma
         self.updated_at ||= Time.utc
       {% end %}
 
+      args = [] of DB::Any
       query = String.build do |qry|
         qry << "INSERT INTO "
         qry << table_name
         qry << "("
         column_values.keys.join(qry, ", ")
         qry << ") VALUES ("
-        column_values.values.join(qry, ", ") { |v, io| v.to_sql_insert_value(io) }
+        column_values.values.join(qry, ", ") do |v, io|
+          io << "?"
+          args << to_db_any(v)
+        end
         qry << ")"
       end
       begin
-        db.exec query
+        db.exec(query, args: args)
       rescue err
         raise DBError.new(err, query)
       end
@@ -555,6 +553,7 @@ module Orma
         {% end %}
       {% end %}
 
+      args_values = [] of DB::Any
       query = String.build do |qry|
         qry << "INSERT INTO "
         qry << table_name
@@ -564,12 +563,13 @@ module Orma
         end
         qry << ") VALUES ("
         args.to_a.join(qry, ", ") do |(key, value), io|
-          transform_in(key, value).to_sql_insert_value(io)
+          io << "?"
+          args_values << to_db_any(transform_in(key, value))
         end
         qry << ")"
       end
       begin
-        res = db.exec(query)
+        res = db.exec(query, args: args_values)
 
         # need to cast `#last_insert_id : Int64` to whatever `id`s type is
         {% if id_type = @type.instance_vars.find { |v| v.annotation(IdColumn) }.type.union_types.find { |t| t != Nil }.type_vars.first %}
@@ -580,6 +580,38 @@ module Orma
       rescue err
         raise DBError.new(err, query)
       end
+    end
+
+    private def to_db_any(value : Orma::Attribute)
+      to_db_any(value.value)
+    end
+
+    private def to_db_any(value : DB::Any) : DB::Any
+      value
+    end
+
+    private def to_db_any(value : Int) : DB::Any
+      value.to_i64
+    end
+
+    private def to_db_any(value) : DB::Any
+      value.as(DB::Any)
+    end
+
+    private def self.to_db_any(value : Orma::Attribute)
+      to_db_any(value.value)
+    end
+
+    private def self.to_db_any(value : DB::Any) : DB::Any
+      value
+    end
+
+    private def self.to_db_any(value : Int) : DB::Any
+      value.to_i64
+    end
+
+    private def self.to_db_any(value) : DB::Any
+      value.as(DB::Any)
     end
 
     # :nodoc:

--- a/src/orma/record.cr
+++ b/src/orma/record.cr
@@ -352,7 +352,7 @@ module Orma
     end
 
     def self.find(id : Int8 | Int16 | Int32 | Int64 | Int128 | Orma::Attribute(Int)?)
-      query_one("SELECT * FROM #{table_name} WHERE id=? LIMIT 1", to_db_any(id))
+      query_one("SELECT * FROM #{table_name} WHERE id=? LIMIT 1", id.try(&.to_i64))
     end
 
     def self.find?(id : Int8 | Int16 | Int32 | Int64 | Int128 | Orma::Attribute(Int)?)
@@ -505,7 +505,7 @@ module Orma
         column_values.to_h.join(qry, ", ") do |(k, v), io|
           io << k
           io << "=?"
-          args << to_db_any(v)
+          args << v.to_db_param
         end
         qry << " WHERE id=?"
       end
@@ -534,7 +534,7 @@ module Orma
         qry << ") VALUES ("
         column_values.values.join(qry, ", ") do |v, io|
           io << "?"
-          args << to_db_any(v)
+          args << v.to_db_param
         end
         qry << ")"
       end
@@ -564,7 +564,7 @@ module Orma
         qry << ") VALUES ("
         args.to_a.join(qry, ", ") do |(key, value), io|
           io << "?"
-          args_values << to_db_any(transform_in(key, value))
+          args_values << transform_in(key, value).to_db_param
         end
         qry << ")"
       end
@@ -580,38 +580,6 @@ module Orma
       rescue err
         raise DBError.new(err, query)
       end
-    end
-
-    private def to_db_any(value : Orma::Attribute)
-      to_db_any(value.value)
-    end
-
-    private def to_db_any(value : DB::Any) : DB::Any
-      value
-    end
-
-    private def to_db_any(value : Int) : DB::Any
-      value.to_i64
-    end
-
-    private def to_db_any(value) : DB::Any
-      value.as(DB::Any)
-    end
-
-    private def self.to_db_any(value : Orma::Attribute)
-      to_db_any(value.value)
-    end
-
-    private def self.to_db_any(value : DB::Any) : DB::Any
-      value
-    end
-
-    private def self.to_db_any(value : Int) : DB::Any
-      value.to_i64
-    end
-
-    private def self.to_db_any(value) : DB::Any
-      value.as(DB::Any)
     end
 
     # :nodoc:

--- a/src/orma/to_sql.cr
+++ b/src/orma/to_sql.cr
@@ -1,6 +1,18 @@
+require "db"
+
 module Orma
   # :nodoc:
   module ToSql
+    def to_prepared_where_condition(io : IO, args : Array(DB::Any))
+      sql_eq_operator(io)
+      io << "?"
+      args << to_db_param
+    end
+
+    def to_db_param : DB::Any
+      self.as(DB::Any)
+    end
+
     def to_sql_where_condition(io : IO)
       sql_eq_operator(io)
       to_sql_value(io)


### PR DESCRIPTION
## Summary
This change updates runtime query execution to pass dynamic values as bound parameters instead of interpolating them into SQL strings.

## What changed
- Updated `Orma::Query` to build SQL with placeholders and a `DB::Any` args list.
- Bound `where` values (including arrays for `IN (...)`) and `limit/offset` values through query args.
- Updated `Orma::Record` runtime operations to use bound args:
 - `.find`
 - `#reload`
 - `#destroy`
 - `#save` update path
 - `.create` and internal insert paths
- Added value-to-`DB::Any` helpers for both class and instance record paths.
- Updated error-message specs to assert placeholder-based SQL.
- Added coverage for array placeholder generation and SQL-like user input handling.

## Validation
- Ran: `crystal spec` (with `CRYSTAL_CACHE_DIR=/tmp/orma-crystal-cache` due cache permission constraints in the default location)
- Result: `98 examples, 0 failures, 0 errors, 0 pending`