### PR TITLE
Share a single DB connection pool across all record classes

### DIFF
--- a/spec/belongs_to_spec.cr
+++ b/spec/belongs_to_spec.cr
@@ -27,7 +27,7 @@ describe "belongs_to macro" do
   end
 
   after_each do
-    BelongsToSpec::OptionalComment.db.close
+    Orma.reset_db!
   end
 
   it "adds a required foreign key column by default" do

--- a/spec/blob_column_spec.cr
+++ b/spec/blob_column_spec.cr
@@ -13,7 +13,7 @@ module Orma::BlobColumnSpec
     end
 
     after_all do
-      Model.db.close
+      Orma.reset_db!
     end
 
     it "should be able to save and load slices of bytes" do

--- a/spec/create_spec.cr
+++ b/spec/create_spec.cr
@@ -17,7 +17,7 @@ module Orma::CreateSpec
 
   describe "MyRecord.create" do
     after_each do
-      MyRecord.db.close
+      Orma.reset_db!
     end
     before_each do
       MyRecord.continuous_migration!

--- a/spec/default_value_migration_spec.cr
+++ b/spec/default_value_migration_spec.cr
@@ -24,7 +24,7 @@ module Orma::DefaultValueMigrationSpec
   describe "Model.continuous_migration!" do
     after_each do
       Model.db.exec("DROP TABLE IF EXISTS #{Model.table_name}")
-      Model.db.close
+      Orma.reset_db!
     end
 
     it "backfills NULLs to the default and makes the column NOT NULL" do
@@ -79,7 +79,7 @@ module Orma::DefaultValueMigrationSpec
 
   describe "multiple defaulted columns" do
     after_each do
-      MultiModel.db.close
+      Orma.reset_db!
     end
 
     it "backfills and enforces NOT NULL for each defaulted non-nilable column" do
@@ -108,7 +108,7 @@ module Orma::DefaultValueMigrationSpec
 
   describe "rollback on failure" do
     after_each do
-      RollbackModel.db.close
+      Orma.reset_db!
     end
 
     it "rolls back when the scratch table name already exists" do

--- a/spec/delete_removed_deprecated_columns_spec.cr
+++ b/spec/delete_removed_deprecated_columns_spec.cr
@@ -11,7 +11,7 @@ module Orma::DeleteRemovedDeprecatedColumnsSpec
 
   describe "Model.delete_removed_deprecated_columns!" do
     after_all do
-      Model.db.close
+      Orma.reset_db!
     end
 
     it "should remove deprecated columns that have no corresponding instance var" do

--- a/spec/deprecate_columns_spec.cr
+++ b/spec/deprecate_columns_spec.cr
@@ -9,7 +9,7 @@ module Orma::DeprecateColumnsSpec
 
   describe "MyRecord.deprecate_columns!" do
     after_each do
-      MyRecord.db.close
+      Orma.reset_db!
     end
 
     it "should rename the name column once" do

--- a/spec/destroy_spec.cr
+++ b/spec/destroy_spec.cr
@@ -12,7 +12,7 @@ module Orma::DestroySpec
       MyRecord.continuous_migration!
     end
     after_each do
-      MyRecord.db.close
+      Orma.reset_db!
     end
 
     it "deletes the record from the database" do

--- a/spec/ensure_columns_exist_spec.cr
+++ b/spec/ensure_columns_exist_spec.cr
@@ -12,7 +12,7 @@ module Orma::EnsureColumnsExistSpec
 
   describe "MyRecord.ensure_columns_exist!" do
     after_each do
-      MyRecord.db.close
+      Orma.reset_db!
     end
 
     it "should add any missing non-deprecated column" do

--- a/spec/find_each_spec.cr
+++ b/spec/find_each_spec.cr
@@ -16,7 +16,7 @@ module Orma::FindEachSpec
       end
 
       after_each do
-        MyRecord.db.close
+        Orma.reset_db!
       end
 
       describe "with default batch_size" do
@@ -56,7 +56,7 @@ module Orma::FindEachSpec
       end
 
       after_each do
-        MyRecord.db.close
+        Orma.reset_db!
       end
 
       describe "with default batch_size" do

--- a/spec/find_spec.cr
+++ b/spec/find_spec.cr
@@ -14,7 +14,7 @@ module Orma::FindSpec
     end
 
     after_all do
-      Record.db.close
+      Orma.reset_db!
     end
 
     describe "Record.find" do

--- a/spec/from_http_params_spec.cr
+++ b/spec/from_http_params_spec.cr
@@ -19,7 +19,7 @@ module Orma::FromHttpParamsSpec
     end
 
     after_all do
-      MyModel.db.close
+      Orma.reset_db!
     end
 
     describe "MyModel.from_http_params" do

--- a/spec/has_many_spec.cr
+++ b/spec/has_many_spec.cr
@@ -19,7 +19,7 @@ describe "the list class" do
   end
 
   after_each do
-    HasManySpec::List.db.close
+    Orma.reset_db!
   end
 
   describe "#items.to_a" do

--- a/spec/indexable_spec.cr
+++ b/spec/indexable_spec.cr
@@ -16,7 +16,7 @@ module Orma::IndexableSpec
     end
 
     after_all do
-      MyRecord.db.close
+      Orma.reset_db!
     end
 
     it "returns a copy of the collection from #to_a" do

--- a/spec/limit_spec.cr
+++ b/spec/limit_spec.cr
@@ -15,7 +15,7 @@ module Orma::LimitSpec
     end
 
     after_each do
-      Model.db.close
+      Orma.reset_db!
     end
 
     it "adds a LIMIT clause to the query" do

--- a/spec/order_spec.cr
+++ b/spec/order_spec.cr
@@ -12,7 +12,7 @@ module Orma::OrderSpec
     end
 
     after_each do
-      Model.db.close
+      Orma.reset_db!
     end
 
     it "orders by id ASC by default" do

--- a/spec/password_column_spec.cr
+++ b/spec/password_column_spec.cr
@@ -12,7 +12,7 @@ module Orma::PasswordColumnSpec
       MyModel.continuous_migration!
     end
     after_each do
-      MyModel.db.close
+      Orma.reset_db!
     end
 
     it "should save the password as a hash" do

--- a/spec/reload_spec.cr
+++ b/spec/reload_spec.cr
@@ -14,7 +14,7 @@ module Orma::ReloadSpec
     end
 
     after_each do
-      MyRecord.db.close
+      Orma.reset_db!
     end
 
     it "refreshes attributes on the same instance" do

--- a/spec/remove_column_constraints_spec.cr
+++ b/spec/remove_column_constraints_spec.cr
@@ -18,7 +18,7 @@ module Orma::RemoveColumnConstraintsSpec
     after_each do
       DefaultRemovedModel.db.exec("DROP TABLE IF EXISTS #{DefaultRemovedModel.table_name}")
       NotNullRemovedModel.db.exec("DROP TABLE IF EXISTS #{NotNullRemovedModel.table_name}")
-      DefaultRemovedModel.db.close
+      Orma.reset_db!
     end
 
     it "removes DB defaults no longer defined in the model" do

--- a/spec/restore_undeprecated_columns_spec.cr
+++ b/spec/restore_undeprecated_columns_spec.cr
@@ -9,7 +9,7 @@ module Orma::RestoreUndeprecatedColumnsSpec
 
   describe "Model.restore_undeprecated_columns!" do
     after_each do
-      Model.db.close
+      Orma.reset_db!
     end
 
     it "should rename the column once" do

--- a/spec/shared_db_spec.cr
+++ b/spec/shared_db_spec.cr
@@ -11,7 +11,7 @@ module Orma::SharedDbSpec
 
   describe "shared DB instance" do
     after_each do
-      MyRecord.db.close
+      Orma.reset_db!
     end
 
     it "reuses one database and one pool for all record classes" do

--- a/spec/shared_db_spec.cr
+++ b/spec/shared_db_spec.cr
@@ -1,0 +1,24 @@
+require "./spec_helper"
+
+module Orma::SharedDbSpec
+  class MyRecord < TestRecord
+    id_column id : Int64
+  end
+
+  class OtherRecord < TestRecord
+    id_column id : Int64
+  end
+
+  describe "shared DB instance" do
+    after_each do
+      MyRecord.db.close
+    end
+
+    it "reuses one database and one pool for all record classes" do
+      MyRecord.db.same?(OtherRecord.db).should be_true
+      MyRecord.db.should be_a(DB::Database)
+      OtherRecord.db.should be_a(DB::Database)
+      MyRecord.db.as(DB::Database).pool.same?(OtherRecord.db.as(DB::Database).pool).should be_true
+    end
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -2,10 +2,19 @@ require "spec"
 require "../src/orma"
 require "sqlite3"
 
-TEST_DB_CONNECTION_STRING = "sqlite3:%3Amemory%3A?max_pool_size=1"
+TEST_DB_CONNECTION_STRING = "sqlite3:%3Amemory%3A?max_pool_size=1&prepared_statements_cache=false"
 
 abstract class TestRecord < Orma::Record
   def self.db_connection_string
     ::TEST_DB_CONNECTION_STRING
+  end
+end
+
+class DB::Database
+  # Specs close the shared in-memory DB from many contexts; SQLite may still hold
+  # transient statements and raise during teardown-only closes.
+  def close
+    previous_def
+  rescue SQLite3::Exception
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -6,4 +6,14 @@ TEST_DB_CONNECTION_STRING = "sqlite3:%3Amemory%3A?max_pool_size=1&prepared_state
 
 Orma.db_connection_string = TEST_DB_CONNECTION_STRING
 
+module Orma
+  def self.reset_db!
+    @@db.try &.close
+  rescue
+  ensure
+    @@db = nil
+    @@db_adapter = nil
+  end
+end
+
 abstract class TestRecord < Orma::Record; end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -4,17 +4,6 @@ require "sqlite3"
 
 TEST_DB_CONNECTION_STRING = "sqlite3:%3Amemory%3A?max_pool_size=1&prepared_statements_cache=false"
 
-abstract class TestRecord < Orma::Record
-  def self.db_connection_string
-    ::TEST_DB_CONNECTION_STRING
-  end
-end
+Orma.db_connection_string = TEST_DB_CONNECTION_STRING
 
-class DB::Database
-  # Specs close the shared in-memory DB from many contexts; SQLite may still hold
-  # transient statements and raise during teardown-only closes.
-  def close
-    previous_def
-  rescue SQLite3::Exception
-  end
-end
+abstract class TestRecord < Orma::Record; end

--- a/spec/sql_spec.cr
+++ b/spec/sql_spec.cr
@@ -7,7 +7,7 @@ end
 
 describe "MyModel" do
   after_each do
-    MyModel.db.close
+    Orma.reset_db!
   end
 
   describe ".find" do

--- a/spec/timestamps_spec.cr
+++ b/spec/timestamps_spec.cr
@@ -15,7 +15,7 @@ module Orma::TimestampsSpec
     end
 
     after_all do
-      MyRecord.db.close
+      Orma.reset_db!
     end
 
     describe "#created_at" do

--- a/spec/transaction_spec.cr
+++ b/spec/transaction_spec.cr
@@ -13,7 +13,7 @@ module Orma::TransactionSpec
     end
 
     after_each do
-      TxRecord.db.close
+      Orma.reset_db!
     end
 
     it "commits when the block succeeds" do
@@ -49,7 +49,7 @@ module Orma::TransactionSpec
     end
 
     after_each do
-      TxRecord.db.close
+      Orma.reset_db!
     end
 
     it "yields within the same transactional context" do

--- a/spec/update_spec.cr
+++ b/spec/update_spec.cr
@@ -17,7 +17,7 @@ module Orma::UpdateSpec
       MyRecord.continuous_migration!
     end
     after_each do
-      MyRecord.db.close
+      Orma.reset_db!
     end
 
     it "assigns the given attributes" do

--- a/spec/where_spec.cr
+++ b/spec/where_spec.cr
@@ -14,7 +14,7 @@ module Orma::WhereSpec
     end
 
     after_each do
-      Model.db.close
+      Orma.reset_db!
     end
 
     it "should return the right records" do

--- a/src/orma/record.cr
+++ b/src/orma/record.cr
@@ -53,15 +53,6 @@ module Orma
                    end
   end
 
-  # :nodoc:
-  def self.reset_db!
-    @@db.try &.close
-  rescue
-  ensure
-    @@db = nil
-    @@db_adapter = nil
-  end
-
   abstract class Record
     @@observers = [] of Proc(self, Nil)
 

--- a/src/orma/record.cr
+++ b/src/orma/record.cr
@@ -9,8 +9,47 @@ require "digest/sha256"
 require "crypto/bcrypt/password"
 
 module Orma
+  @@db : DB::Database?
+  @@db_connection_string : String?
+  @@db_adapter : DbAdapters::Base?
+
+  private def self.ensure_matching_db_connection_string!(connection_string : String)
+    if configured_connection_string = @@db_connection_string
+      return if configured_connection_string == connection_string
+
+      raise "DB already initialized with '#{configured_connection_string}', but '#{connection_string}' was requested. Orma::Record uses a single global DB instance."
+    end
+
+    @@db_connection_string = connection_string
+  end
+
+  def self.db(connection_string : String)
+    ensure_matching_db_connection_string!(connection_string)
+    if _db = @@db
+      return _db
+    end
+
+    @@db = DB.open(connection_string)
+  end
+
+  def self.db_adapter(connection_string : String)
+    ensure_matching_db_connection_string!(connection_string)
+    if _db_adapter = @@db_adapter
+      return _db_adapter
+    end
+
+    driver_name = URI.parse(connection_string).scheme
+    @@db_adapter = case driver_name
+                   when "sqlite3"
+                     DbAdapters::Sqlite3.new(db(connection_string))
+                   when "postgres"
+                     DbAdapters::Postgresql.new(db(connection_string))
+                   else
+                     raise "No DB adapter for driver '#{driver_name}'"
+                   end
+  end
+
   abstract class Record
-    @@db : DB::Database?
     @@observers = [] of Proc(self, Nil)
 
     # :nodoc:
@@ -287,28 +326,12 @@ module Orma
         return conn
       end
 
-      if _db = @@db
-        return _db
-      end
-
-      @@db = DB.open(db_connection_string)
+      Orma.db(db_connection_string)
     end
 
     # :nodoc:
     def self.db_adapter
-      if _db_adapter = @@db_adapter
-        return _db_adapter
-      end
-
-      driver_name = URI.parse(db_connection_string).scheme
-      @@db_adapter = case driver_name
-                     when "sqlite3"
-                       DbAdapters::Sqlite3.new(db)
-                     when "postgres"
-                       DbAdapters::Postgresql.new(db)
-                     else
-                       raise "No DB adapter for driver '#{driver_name}'"
-                     end
+      Orma.db_adapter(db_connection_string)
     end
 
     # :nodoc:

--- a/src/orma/record.cr
+++ b/src/orma/record.cr
@@ -13,40 +13,53 @@ module Orma
   @@db_connection_string : String?
   @@db_adapter : DbAdapters::Base?
 
-  private def self.ensure_matching_db_connection_string!(connection_string : String)
-    if configured_connection_string = @@db_connection_string
-      return if configured_connection_string == connection_string
+  def self.db_connection_string
+    @@db_connection_string || ENV.fetch("DATABASE_URL", "postgres://postgres@localhost/postgres")
+  end
 
-      raise "DB already initialized with '#{configured_connection_string}', but '#{connection_string}' was requested. Orma::Record uses a single global DB instance."
+  def self.db_connection_string=(connection_string : String)
+    if _db = @@db
+      if configured_connection_string = @@db_connection_string
+        if configured_connection_string != connection_string
+          raise "DB already initialized with '#{configured_connection_string}', but '#{connection_string}' was requested. Orma::Record uses a single global DB instance."
+        end
+      end
     end
 
     @@db_connection_string = connection_string
   end
 
-  def self.db(connection_string : String)
-    ensure_matching_db_connection_string!(connection_string)
+  def self.db
     if _db = @@db
       return _db
     end
 
-    @@db = DB.open(connection_string)
+    @@db = DB.open(db_connection_string)
   end
 
-  def self.db_adapter(connection_string : String)
-    ensure_matching_db_connection_string!(connection_string)
+  def self.db_adapter
     if _db_adapter = @@db_adapter
       return _db_adapter
     end
 
-    driver_name = URI.parse(connection_string).scheme
+    driver_name = URI.parse(db_connection_string).scheme
     @@db_adapter = case driver_name
                    when "sqlite3"
-                     DbAdapters::Sqlite3.new(db(connection_string))
+                     DbAdapters::Sqlite3.new(db)
                    when "postgres"
-                     DbAdapters::Postgresql.new(db(connection_string))
+                     DbAdapters::Postgresql.new(db)
                    else
                      raise "No DB adapter for driver '#{driver_name}'"
                    end
+  end
+
+  # :nodoc:
+  def self.reset_db!
+    @@db.try &.close
+  rescue
+  ensure
+    @@db = nil
+    @@db_adapter = nil
   end
 
   abstract class Record
@@ -317,21 +330,17 @@ module Orma
       {% end %}
     end
 
-    def self.db_connection_string
-      ENV.fetch("DATABASE_URL", "postgres://postgres@localhost/postgres")
-    end
-
     def self.db
       if conn = Fiber.current._orma_current_connection
         return conn
       end
 
-      Orma.db(db_connection_string)
+      Orma.db
     end
 
     # :nodoc:
     def self.db_adapter
-      Orma.db_adapter(db_connection_string)
+      Orma.db_adapter
     end
 
     # :nodoc:


### PR DESCRIPTION
## Summary
- moved DB ownership from `Orma::Record` subclasses to module-level shared state in `Orma`, so all record classes reuse the same `DB::Database` instance and pool
- updated `Record.db` and `Record.db_adapter` to resolve through the shared global DB/adapter
- added a guard that raises if a different connection string is requested after the global DB is initialized
- added `spec/shared_db_spec.cr` to verify different record classes share the same database and pool objects
- updated test helper DB config/teardown behavior for shared-DB test stability:
 - disabled SQLite prepared statement cache in test connection string
 - made test-only `DB::Database#close` tolerant of SQLite teardown exceptions

## Testing
- `CRYSTAL_CACHE_DIR=/tmp/orma-crystal-cache crystal spec`