### PR TITLE
Fix PostgreSQL prepared statement placeholders

### DIFF
--- a/spec/postgresql_prepared_statement_spec.cr
+++ b/spec/postgresql_prepared_statement_spec.cr
@@ -1,0 +1,94 @@
+require "./spec_helper"
+
+module Orma::PostgresqlPreparedStatementSpec
+  class Record < TestRecord
+    id_column id : Int64
+    column name : String
+    column age : Int32
+
+    def self.db_adapter
+      Orma::DbAdapters::Postgresql.new(db)
+    end
+  end
+
+  describe "PostgreSQL prepared statements" do
+    describe "via .find" do
+      it "uses numbered placeholders" do
+        err = expect_raises(Orma::DBError) do
+          Record.find(2)
+        end
+
+        err.message.should eq("SQLite3::Exception: no such table: orma_postgresql_prepared_statement_spec_records\n\nSQL Query: SELECT * FROM orma_postgresql_prepared_statement_spec_records WHERE id=$1 LIMIT 1")
+      end
+    end
+
+    describe "via #reload" do
+      it "uses numbered placeholders" do
+        err = expect_raises(Orma::DBError) do
+          Record.new(id: 1_i64, name: "Foo", age: 1).reload
+        end
+
+        err.message.should eq("SQLite3::Exception: no such table: orma_postgresql_prepared_statement_spec_records\n\nSQL Query: SELECT * FROM orma_postgresql_prepared_statement_spec_records WHERE id=$1 LIMIT 1")
+      end
+    end
+
+    describe "via #to_a" do
+      it "uses numbered placeholders for scalar conditions" do
+        err = expect_raises(Orma::DBError) do
+          Record.where(name: "test").to_a
+        end
+
+        err.message.should eq("SQLite3::Exception: no such table: orma_postgresql_prepared_statement_spec_records\n\nSQL Query: SELECT * FROM orma_postgresql_prepared_statement_spec_records WHERE name=$1")
+      end
+
+      it "uses numbered placeholders for list conditions" do
+        err = expect_raises(Orma::DBError) do
+          Record.where(id: [1_i64, 2_i64]).to_a
+        end
+
+        err.message.should eq("SQLite3::Exception: no such table: orma_postgresql_prepared_statement_spec_records\n\nSQL Query: SELECT * FROM orma_postgresql_prepared_statement_spec_records WHERE id IN ($1,$2)")
+      end
+
+      it "continues numbering through limits" do
+        err = expect_raises(Orma::DBError) do
+          Record.where(name: "test").limit(5).to_a
+        end
+
+        err.message.should eq("SQLite3::Exception: no such table: orma_postgresql_prepared_statement_spec_records\n\nSQL Query: SELECT * FROM orma_postgresql_prepared_statement_spec_records WHERE name=$1 LIMIT $2")
+      end
+    end
+
+    describe "via #count" do
+      it "uses numbered placeholders" do
+        err = expect_raises(Orma::DBError) do
+          Record.where(name: "test", age: 1).count
+        end
+
+        err.message.should eq("SQLite3::Exception: no such table: orma_postgresql_prepared_statement_spec_records\n\nSQL Query: SELECT COUNT(*) FROM orma_postgresql_prepared_statement_spec_records WHERE name=$1 AND age=$2")
+      end
+    end
+
+    describe "via .create" do
+      it "uses numbered placeholders" do
+        err = expect_raises(Orma::DBError) do
+          Record.create(name: "Blah", age: 1)
+        end
+
+        err.message.should eq("SQLite3::Exception: no such table: orma_postgresql_prepared_statement_spec_records\n\nSQL Query: INSERT INTO orma_postgresql_prepared_statement_spec_records(name, age) VALUES ($1, $2)")
+      end
+    end
+
+    describe "via #save on an existing record" do
+      it "uses numbered placeholders" do
+        rec = Record.new(id: 1_i64, name: "Foo", age: 1)
+
+        err = expect_raises(Orma::DBError) do
+          rec.name = "Bar"
+          rec.save
+        end
+
+        err.message.should eq("SQLite3::Exception: no such table: orma_postgresql_prepared_statement_spec_records\n\nSQL Query: UPDATE orma_postgresql_prepared_statement_spec_records SET name=$1, age=$2 WHERE id=$3")
+      end
+    end
+  end
+end

--- a/spec/postgresql_prepared_statement_spec.cr
+++ b/spec/postgresql_prepared_statement_spec.cr
@@ -1,80 +1,153 @@
 require "./spec_helper"
 
 module Orma::PostgresqlPreparedStatementSpec
+  class FakeDB
+    record Call, method : Symbol, sql : String, args : Array(DB::Any)
+
+    class QueryCalled < Exception; end
+
+    @@calls = [] of Call
+
+    def self.calls
+      @@calls
+    end
+
+    def self.reset!
+      @@calls.clear
+    end
+
+    def query(sql, *, args : Enumerable? = nil, &)
+      record_call(:query, sql, args)
+    end
+
+    def query_one(sql, *args_, args : Enumerable? = nil, &)
+      record_call(:query_one, sql, args || args_)
+    end
+
+    def scalar(sql, *, args : Enumerable? = nil)
+      record_call(:scalar, sql, args)
+    end
+
+    def exec(sql, *args_, args : Enumerable? = nil)
+      record_call(:exec, sql, args || args_)
+    end
+
+    private def record_call(method, sql, args)
+      call_args = [] of DB::Any
+      args.try &.each { |arg| call_args << arg.as(DB::Any) }
+      @@calls << Call.new(method, sql, call_args)
+      raise QueryCalled.new
+    end
+  end
+
   class Record < TestRecord
     id_column id : Int64
     column name : String
     column age : Int32
 
-    def self.db_adapter
-      Orma::DbAdapters::Postgresql.new(db)
+    class FakePostgresqlAdapter
+      def db_type_for(klass)
+        raise "not used"
+      end
+
+      def primary_key_column_statement
+        raise "not used"
+      end
+
+      def query_index_names
+        raise "not used"
+      end
+
+      def query_column_names(table_name : String)
+        raise "not used"
+      end
+
+      def sync_column_constraints(table_name : String, constraints : Hash(String, Orma::DbAdapters::DesiredColumnConstraints))
+        raise "not used"
+      end
+
+      def add_parameter_placeholder(io : IO, args : Array(DB::Any), value : DB::Any)
+        io << "$#{args.size + 1}"
+        args << value
+      end
     end
+
+    @@db = FakeDB.new
+    @@db_adapter = FakePostgresqlAdapter.new
+
+    def self.db
+      @@db
+    end
+
+    def self.db_adapter
+      @@db_adapter
+    end
+  end
+
+  private def self.db_args(*values)
+    values.to_a.map(&.as(DB::Any))
+  end
+
+  private def self.expect_db_call(call, &)
+    FakeDB.reset!
+
+    expect_raises(Orma::DBError) do
+      yield
+    end
+
+    FakeDB.calls.should eq([call])
   end
 
   describe "PostgreSQL prepared statements" do
     describe "via .find" do
       it "uses numbered placeholders" do
-        err = expect_raises(Orma::DBError) do
+        expect_db_call(FakeDB::Call.new(:query_one, "SELECT * FROM orma_postgresql_prepared_statement_spec_records WHERE id=$1 LIMIT 1", db_args(2_i64))) do
           Record.find(2)
         end
-
-        err.message.should eq("SQLite3::Exception: no such table: orma_postgresql_prepared_statement_spec_records\n\nSQL Query: SELECT * FROM orma_postgresql_prepared_statement_spec_records WHERE id=$1 LIMIT 1")
       end
     end
 
     describe "via #reload" do
       it "uses numbered placeholders" do
-        err = expect_raises(Orma::DBError) do
+        expect_db_call(FakeDB::Call.new(:query_one, "SELECT * FROM orma_postgresql_prepared_statement_spec_records WHERE id=$1 LIMIT 1", db_args(1_i64))) do
           Record.new(id: 1_i64, name: "Foo", age: 1).reload
         end
-
-        err.message.should eq("SQLite3::Exception: no such table: orma_postgresql_prepared_statement_spec_records\n\nSQL Query: SELECT * FROM orma_postgresql_prepared_statement_spec_records WHERE id=$1 LIMIT 1")
       end
     end
 
     describe "via #to_a" do
       it "uses numbered placeholders for scalar conditions" do
-        err = expect_raises(Orma::DBError) do
+        expect_db_call(FakeDB::Call.new(:query, "SELECT * FROM orma_postgresql_prepared_statement_spec_records WHERE name=$1", db_args("test"))) do
           Record.where(name: "test").to_a
         end
-
-        err.message.should eq("SQLite3::Exception: no such table: orma_postgresql_prepared_statement_spec_records\n\nSQL Query: SELECT * FROM orma_postgresql_prepared_statement_spec_records WHERE name=$1")
       end
 
       it "uses numbered placeholders for list conditions" do
-        err = expect_raises(Orma::DBError) do
+        expect_db_call(FakeDB::Call.new(:query, "SELECT * FROM orma_postgresql_prepared_statement_spec_records WHERE id IN ($1,$2)", db_args(1_i64, 2_i64))) do
           Record.where(id: [1_i64, 2_i64]).to_a
         end
-
-        err.message.should eq("SQLite3::Exception: no such table: orma_postgresql_prepared_statement_spec_records\n\nSQL Query: SELECT * FROM orma_postgresql_prepared_statement_spec_records WHERE id IN ($1,$2)")
       end
 
       it "continues numbering through limits" do
-        err = expect_raises(Orma::DBError) do
+        expect_db_call(FakeDB::Call.new(:query, "SELECT * FROM orma_postgresql_prepared_statement_spec_records WHERE name=$1 LIMIT $2", db_args("test", 5_i64))) do
           Record.where(name: "test").limit(5).to_a
         end
-
-        err.message.should eq("SQLite3::Exception: no such table: orma_postgresql_prepared_statement_spec_records\n\nSQL Query: SELECT * FROM orma_postgresql_prepared_statement_spec_records WHERE name=$1 LIMIT $2")
       end
     end
 
     describe "via #count" do
       it "uses numbered placeholders" do
-        err = expect_raises(Orma::DBError) do
+        expect_db_call(FakeDB::Call.new(:scalar, "SELECT COUNT(*) FROM orma_postgresql_prepared_statement_spec_records WHERE name=$1 AND age=$2", db_args("test", 1))) do
           Record.where(name: "test", age: 1).count
         end
-
-        err.message.should eq("SQLite3::Exception: no such table: orma_postgresql_prepared_statement_spec_records\n\nSQL Query: SELECT COUNT(*) FROM orma_postgresql_prepared_statement_spec_records WHERE name=$1 AND age=$2")
       end
     end
 
     describe "via .create" do
       it "uses numbered placeholders" do
-        err = expect_raises(Orma::DBError) do
+        expect_db_call(FakeDB::Call.new(:exec, "INSERT INTO orma_postgresql_prepared_statement_spec_records(name, age) VALUES ($1, $2)", db_args("Blah", 1))) do
           Record.create(name: "Blah", age: 1)
         end
-
-        err.message.should eq("SQLite3::Exception: no such table: orma_postgresql_prepared_statement_spec_records\n\nSQL Query: INSERT INTO orma_postgresql_prepared_statement_spec_records(name, age) VALUES ($1, $2)")
       end
     end
 
@@ -82,12 +155,10 @@ module Orma::PostgresqlPreparedStatementSpec
       it "uses numbered placeholders" do
         rec = Record.new(id: 1_i64, name: "Foo", age: 1)
 
-        err = expect_raises(Orma::DBError) do
+        expect_db_call(FakeDB::Call.new(:exec, "UPDATE orma_postgresql_prepared_statement_spec_records SET name=$1, age=$2 WHERE id=$3", db_args("Bar", 1, 1_i64))) do
           rec.name = "Bar"
           rec.save
         end
-
-        err.message.should eq("SQLite3::Exception: no such table: orma_postgresql_prepared_statement_spec_records\n\nSQL Query: UPDATE orma_postgresql_prepared_statement_spec_records SET name=$1, age=$2 WHERE id=$3")
       end
     end
   end

--- a/spec/postgresql_prepared_statement_spec.cr
+++ b/spec/postgresql_prepared_statement_spec.cr
@@ -1,12 +1,16 @@
 require "./spec_helper"
 
 module Orma::PostgresqlPreparedStatementSpec
-  class FakeDB
+  class FakeDB < DB::Database
     record Call, method : Symbol, sql : String, args : Array(DB::Any)
 
     class QueryCalled < Exception; end
 
     @@calls = [] of Call
+
+    def initialize
+      super(DB::Connection::Options.new, DB::Pool::Options.new(initial_pool_size: 0)) { raise "not used" }
+    end
 
     def self.calls
       @@calls
@@ -45,35 +49,8 @@ module Orma::PostgresqlPreparedStatementSpec
     column name : String
     column age : Int32
 
-    class FakePostgresqlAdapter
-      def db_type_for(klass)
-        raise "not used"
-      end
-
-      def primary_key_column_statement
-        raise "not used"
-      end
-
-      def query_index_names
-        raise "not used"
-      end
-
-      def query_column_names(table_name : String)
-        raise "not used"
-      end
-
-      def sync_column_constraints(table_name : String, constraints : Hash(String, Orma::DbAdapters::DesiredColumnConstraints))
-        raise "not used"
-      end
-
-      def add_parameter_placeholder(io : IO, args : Array(DB::Any), value : DB::Any)
-        io << "$#{args.size + 1}"
-        args << value
-      end
-    end
-
     @@db = FakeDB.new
-    @@db_adapter = FakePostgresqlAdapter.new
+    @@db_adapter = Orma::DbAdapters::Postgresql.new(@@db)
 
     def self.db
       @@db

--- a/src/ext/array.cr
+++ b/src/ext/array.cr
@@ -16,7 +16,7 @@ class Array(T)
     io << " IN "
   end
 
-  def to_prepared_where_condition(io : IO, args : Array(DB::Any), db_adapter)
+  def to_prepared_where_condition(io : IO, args : Array(DB::Any), db_adapter : Orma::DbAdapters::Base)
     sql_eq_operator(io)
 
     io << "("

--- a/src/ext/array.cr
+++ b/src/ext/array.cr
@@ -16,7 +16,7 @@ class Array(T)
     io << " IN "
   end
 
-  def to_prepared_where_condition(io : IO, args : Array(DB::Any), db_adapter : Orma::DbAdapters::Base)
+  def to_prepared_where_condition(io : IO, args : Array(DB::Any), db_adapter)
     sql_eq_operator(io)
 
     io << "("

--- a/src/ext/array.cr
+++ b/src/ext/array.cr
@@ -4,14 +4,6 @@ require "../orma/to_sql"
 class Array(T)
   include Orma::ToSql
 
-  private struct PreparedParamPlaceholder
-    include Orma::ToSql
-
-    def to_sql_value(io : IO)
-      io << "?"
-    end
-  end
-
   def to_sql_value(io : IO)
     io << "("
     join(io, ",") do |item, io|
@@ -24,10 +16,13 @@ class Array(T)
     io << " IN "
   end
 
-  def to_prepared_where_condition(io : IO, args : Array(DB::Any))
+  def to_prepared_where_condition(io : IO, args : Array(DB::Any), db_adapter : Orma::DbAdapters::Base)
     sql_eq_operator(io)
 
-    Array(PreparedParamPlaceholder).new(size) { PreparedParamPlaceholder.new }.to_sql_value(io)
-    each { |item| args << item.to_db_param }
+    io << "("
+    join(io, ",") do |item, io|
+      db_adapter.add_parameter_placeholder(io, args, item.to_db_param)
+    end
+    io << ")"
   end
 end

--- a/src/orma/db_adapters/base.cr
+++ b/src/orma/db_adapters/base.cr
@@ -10,6 +10,15 @@ abstract class Orma::DbAdapters::Base
 
   def initialize(@db); end
 
+  def parameter_placeholder(args : Array(DB::Any))
+    "?"
+  end
+
+  def add_parameter_placeholder(io : IO, args : Array(DB::Any), value : DB::Any)
+    io << parameter_placeholder(args)
+    args << value
+  end
+
   def query_column_names(table_name : String) : Array(String)
     names = [] of String
     db.query("SELECT * FROM #{table_name} LIMIT 1") do |res|

--- a/src/orma/db_adapters/postgresql.cr
+++ b/src/orma/db_adapters/postgresql.cr
@@ -17,6 +17,10 @@ class Orma::DbAdapters::Postgresql < Orma::DbAdapters::Base
     "PRIMARY KEY"
   end
 
+  def parameter_placeholder(args : Array(DB::Any))
+    "$#{args.size + 1}"
+  end
+
   def query_index_names
     names = [] of String
 

--- a/src/orma/query.cr
+++ b/src/orma/query.cr
@@ -124,7 +124,7 @@ abstract class Orma::Query
           end
 
           str << %value{ivar}.name
-          %value{ivar}.value.to_prepared_where_condition(str, args)
+          %value{ivar}.value.to_prepared_where_condition(str, args, db_adapter)
         end
       {% end %}
     end
@@ -163,16 +163,22 @@ abstract class Orma::Query
   private def limit_clause(args : Array(DB::Any))
     return nil unless limit = @limit
 
-    args << limit
-    " LIMIT ?"
+    String.build do |str|
+      str << " LIMIT "
+      db_adapter.add_parameter_placeholder(str, args, limit)
+    end
   end
 
   private def load_batch(batch_no, batch_size)
     base = build_query("*", include_limit: false)
-    sql = "#{base.sql} LIMIT ? OFFSET ?"
     args = base.args.dup
-    args << batch_size.to_i64
-    args << (batch_no * batch_size).to_i64
+    sql = String.build do |str|
+      str << base.sql
+      str << " LIMIT "
+      db_adapter.add_parameter_placeholder(str, args, batch_size.to_i64)
+      str << " OFFSET "
+      db_adapter.add_parameter_placeholder(str, args, (batch_no * batch_size).to_i64)
+    end
     begin
       db.query(sql, args: args) do |res|
         load_many_from_result(res)

--- a/src/orma/record.cr
+++ b/src/orma/record.cr
@@ -69,7 +69,7 @@ module Orma
       class Query < ::Orma::Query
         PARENT = {{@type}}
 
-        delegate :db, :table_name, :load_many_from_result, to: PARENT
+        delegate :db, :db_adapter, :table_name, :load_many_from_result, to: PARENT
 
         @collection : Array({{@type}})?
       end
@@ -366,6 +366,10 @@ module Orma
       self.class.db
     end
 
+    def db_adapter
+      self.class.db_adapter
+    end
+
     def self.table_name
       {{ @type.name.underscore.gsub(/::/, "_").stringify + "s" }}
     end
@@ -375,7 +379,13 @@ module Orma
     end
 
     def self.find(id : Int8 | Int16 | Int32 | Int64 | Int128 | Orma::Attribute(Int)?)
-      query_one("SELECT * FROM #{table_name} WHERE id=? LIMIT 1", id.try(&.to_i64))
+      args = [] of DB::Any
+      sql = String.build do |qry|
+        qry << "SELECT * FROM #{table_name} WHERE id="
+        db_adapter.add_parameter_placeholder(qry, args, id.try(&.to_i64))
+        qry << " LIMIT 1"
+      end
+      query_one(sql, args: args)
     end
 
     def self.find?(id : Int8 | Int16 | Int32 | Int64 | Int128 | Orma::Attribute(Int)?)
@@ -387,8 +397,12 @@ module Orma
         raise "Cannot reload record without `id`"
       end
 
-      sql = "SELECT * FROM #{table_name} WHERE id=? LIMIT 1"
-      args = [_id] of DB::Any
+      args = [] of DB::Any
+      sql = String.build do |qry|
+        qry << "SELECT * FROM #{table_name} WHERE id="
+        db_adapter.add_parameter_placeholder(qry, args, _id)
+        qry << " LIMIT 1"
+      end
       begin
         db.query_one(sql, args: args) do |res|
           load_attributes_from_result_set(res)
@@ -445,8 +459,12 @@ module Orma
         raise "Cannot destroy record without `id`"
       end
 
-      sql = "DELETE FROM #{table_name} WHERE id=?"
-      db.exec(sql, _id)
+      args = [] of DB::Any
+      sql = String.build do |qry|
+        qry << "DELETE FROM #{table_name} WHERE id="
+        db_adapter.add_parameter_placeholder(qry, args, _id)
+      end
+      db.exec(sql, args: args)
     end
 
     def transaction(&block : -> T) : T forall T
@@ -527,12 +545,12 @@ module Orma
         qry << " SET "
         column_values.to_h.join(qry, ", ") do |(k, v), io|
           io << k
-          io << "=?"
-          args << v.to_db_param
+          io << "="
+          db_adapter.add_parameter_placeholder(io, args, v.to_db_param)
         end
-        qry << " WHERE id=?"
+        qry << " WHERE id="
+        db_adapter.add_parameter_placeholder(qry, args, _id)
       end
-      args << _id
       begin
         db.exec(query, args: args)
       rescue err
@@ -556,8 +574,7 @@ module Orma
         column_values.keys.join(qry, ", ")
         qry << ") VALUES ("
         column_values.values.join(qry, ", ") do |v, io|
-          io << "?"
-          args << v.to_db_param
+          db_adapter.add_parameter_placeholder(io, args, v.to_db_param)
         end
         qry << ")"
       end
@@ -586,8 +603,7 @@ module Orma
         end
         qry << ") VALUES ("
         args.to_a.join(qry, ", ") do |(key, value), io|
-          io << "?"
-          args_values << transform_in(key, value).to_db_param
+          db_adapter.add_parameter_placeholder(io, args_values, transform_in(key, value).to_db_param)
         end
         qry << ")"
       end

--- a/src/orma/to_sql.cr
+++ b/src/orma/to_sql.cr
@@ -3,7 +3,7 @@ require "db"
 module Orma
   # :nodoc:
   module ToSql
-    def to_prepared_where_condition(io : IO, args : Array(DB::Any), db_adapter)
+    def to_prepared_where_condition(io : IO, args : Array(DB::Any), db_adapter : Orma::DbAdapters::Base)
       sql_eq_operator(io)
       db_adapter.add_parameter_placeholder(io, args, to_db_param)
     end

--- a/src/orma/to_sql.cr
+++ b/src/orma/to_sql.cr
@@ -3,10 +3,9 @@ require "db"
 module Orma
   # :nodoc:
   module ToSql
-    def to_prepared_where_condition(io : IO, args : Array(DB::Any))
+    def to_prepared_where_condition(io : IO, args : Array(DB::Any), db_adapter : Orma::DbAdapters::Base)
       sql_eq_operator(io)
-      io << "?"
-      args << to_db_param
+      db_adapter.add_parameter_placeholder(io, args, to_db_param)
     end
 
     def to_db_param : DB::Any

--- a/src/orma/to_sql.cr
+++ b/src/orma/to_sql.cr
@@ -3,7 +3,7 @@ require "db"
 module Orma
   # :nodoc:
   module ToSql
-    def to_prepared_where_condition(io : IO, args : Array(DB::Any), db_adapter : Orma::DbAdapters::Base)
+    def to_prepared_where_condition(io : IO, args : Array(DB::Any), db_adapter)
       sql_eq_operator(io)
       db_adapter.add_parameter_placeholder(io, args, to_db_param)
     end


### PR DESCRIPTION
## Summary
- Add adapter-specific placeholder generation for prepared statements.
- Use `$1`, `$2`, etc. for PostgreSQL while keeping `?` for SQLite.
- Cover PostgreSQL SQL generation for find, reload, where, count, create, update, lists, and limits.

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/orma-crystal-cache crystal spec`