### PR TITLE
Differentiate data types for primary keys and other columns

### DIFF
--- a/spec/db_adapters/postgresql_spec.cr
+++ b/spec/db_adapters/postgresql_spec.cr
@@ -1,0 +1,20 @@
+require "../spec_helper"
+
+describe Orma::DbAdapters::Postgresql do
+  db = uninitialized DB::Database
+  adapter = Orma::DbAdapters::Postgresql.new(db)
+
+  it "uses plain integer types for non-primary-key columns" do
+    adapter.db_type_for(Int64).should eq("BIGINT")
+    adapter.db_type_for(Int32).should eq("INTEGER")
+  end
+
+  it "uses serial integer types for primary-key columns" do
+    adapter.primary_key_db_type_for(Int64).should eq("BIGSERIAL")
+    adapter.primary_key_db_type_for(Int32).should eq("SERIAL")
+  end
+
+  it "uses Postgres binary storage for byte slices" do
+    adapter.db_type_for(Slice(UInt8)).should eq("BYTEA")
+  end
+end

--- a/src/orma/db_adapters/base.cr
+++ b/src/orma/db_adapters/base.cr
@@ -2,6 +2,7 @@ require "../db_adapters"
 
 abstract class Orma::DbAdapters::Base
   abstract def db_type_for(klass)
+  abstract def primary_key_db_type_for(klass)
   abstract def primary_key_column_statement
   abstract def query_index_names
   abstract def sync_column_constraints(table_name : String, constraints : Hash(String, Orma::DbAdapters::DesiredColumnConstraints))

--- a/src/orma/db_adapters/postgresql.cr
+++ b/src/orma/db_adapters/postgresql.cr
@@ -4,12 +4,21 @@ require "./base"
 class Orma::DbAdapters::Postgresql < Orma::DbAdapters::Base
   def db_type_for(klass)
     case klass
-    in Int64.class        then "BIGSERIAL"
-    in Int32.class        then "SERIAL"
+    in Int64.class        then "BIGINT"
+    in Int32.class        then "INTEGER"
     in String.class       then "VARCHAR"
     in Bool.class         then "BOOLEAN"
     in Time.class         then "TIMESTAMP"
-    in Slice(UInt8).class then "BLOB"
+    in Slice(UInt8).class then "BYTEA"
+    end
+  end
+
+  def primary_key_db_type_for(klass)
+    case klass
+    when Int64.class then "BIGSERIAL"
+    when Int32.class then "SERIAL"
+    else
+      db_type_for(klass)
     end
   end
 

--- a/src/orma/db_adapters/sqlite3.cr
+++ b/src/orma/db_adapters/sqlite3.cr
@@ -34,6 +34,10 @@ class Orma::DbAdapters::Sqlite3 < Orma::DbAdapters::Base
     "PRIMARY KEY AUTOINCREMENT"
   end
 
+  def primary_key_db_type_for(klass)
+    db_type_for(klass)
+  end
+
   def query_column_names(table_name : String) : Array(String)
     sqlite_column_infos(table_name).map(&.name)
   end

--- a/src/orma/record.cr
+++ b/src/orma/record.cr
@@ -781,7 +781,7 @@ module Orma
     macro db_column_statements
       [
         {% for var in @type.instance_vars.select { |v| v.annotation(IdColumn) } %}
-          "{{var.name.id}} #{db_type_for({{var.type.union_types.find { |t| t != Nil }.type_vars.first.id}})} #{primary_key_column_statement}",
+          "{{var.name.id}} #{primary_key_db_type_for({{var.type.union_types.find { |t| t != Nil }.type_vars.first.id}})} #{primary_key_column_statement}",
         {% end %}
         {% for var in @type.instance_vars.select { |v| v.annotation(Column) } %}
           begin
@@ -804,6 +804,11 @@ module Orma
     # :nodoc:
     def self.db_type_for(klass)
       db_adapter.db_type_for(klass)
+    end
+
+    # :nodoc:
+    def self.primary_key_db_type_for(klass)
+      db_adapter.primary_key_db_type_for(klass)
     end
 
     # :nodoc:


### PR DESCRIPTION
PostgreSQL doesn't support using `SERIAL` with a `DEFAULT` value.