### PR TITLE
Add default SQLite connection options

### DIFF
--- a/spec/db_adapters/sqlite3_spec.cr
+++ b/spec/db_adapters/sqlite3_spec.cr
@@ -1,0 +1,17 @@
+require "../spec_helper"
+
+describe Orma::DbAdapters::Sqlite3 do
+  describe ".add_default_connection_string_options" do
+    it "adds default options missing from the connection string" do
+      connection_string = Orma::DbAdapters::Sqlite3.add_default_connection_string_options("sqlite3:%3Amemory%3A?max_pool_size=1")
+
+      URI.parse(connection_string).query_params.should eq(URI::Params.parse("max_pool_size=1&journal_mode=wal&synchronous=normal&busy_timeout=5000"))
+    end
+
+    it "preserves configured options" do
+      connection_string = Orma::DbAdapters::Sqlite3.add_default_connection_string_options("sqlite3:%3Amemory%3A?journal_mode=delete&synchronous=full&busy_timeout=100")
+
+      URI.parse(connection_string).query_params.should eq(URI::Params.parse("journal_mode=delete&synchronous=full&busy_timeout=100"))
+    end
+  end
+end

--- a/src/orma/db_adapters/sqlite3.cr
+++ b/src/orma/db_adapters/sqlite3.cr
@@ -2,6 +2,8 @@ require "./base"
 
 # :nodoc:
 class Orma::DbAdapters::Sqlite3 < Orma::DbAdapters::Base
+  DEFAULT_CONNECTION_STRING_OPTIONS = {"journal_mode" => "wal", "synchronous" => "normal", "busy_timeout" => "5000"}
+
   struct ColumnInfo
     getter name : String
     getter type : String
@@ -17,6 +19,14 @@ class Orma::DbAdapters::Sqlite3 < Orma::DbAdapters::Base
       @dflt_value = res.read(String?)
       @pk = res.read(Int64) > 0
     end
+  end
+
+  def self.add_default_connection_string_options(connection_string : String) : String
+    uri = URI.parse(connection_string)
+    params = uri.query_params
+    DEFAULT_CONNECTION_STRING_OPTIONS.each { |key, value| params[key] = value unless params.has_key?(key) }
+    uri.query = params.to_s
+    uri.to_s
   end
 
   def db_type_for(klass)

--- a/src/orma/record.cr
+++ b/src/orma/record.cr
@@ -14,7 +14,10 @@ module Orma
   @@db_adapter : DbAdapters::Base?
 
   def self.db_connection_string
-    @@db_connection_string || ENV.fetch("DATABASE_URL", "postgres://postgres@localhost/postgres")
+    connection_string = @@db_connection_string || ENV.fetch("DATABASE_URL", "postgres://postgres@localhost/postgres")
+    return connection_string unless URI.parse(connection_string).scheme == "sqlite3"
+
+    DbAdapters::Sqlite3.add_default_connection_string_options(connection_string)
   end
 
   def self.db_connection_string=(connection_string : String)


### PR DESCRIPTION
## Summary
- add WAL, normal synchronous mode, and a 5000ms busy timeout by default
- preserve explicitly configured SQLite options
- add focused adapter specs

## Testing
- `crystal spec --error-trace`
- `crystal build src/orma.cr`